### PR TITLE
Add Running E2E Tests To Docker Compose Framework and CI

### DIFF
--- a/.github/workflows/on_pr_build_push_vet_images.yml
+++ b/.github/workflows/on_pr_build_push_vet_images.yml
@@ -41,11 +41,20 @@ jobs:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-# TODO: Add vetting of image(s), for now just push unvetted to vetted
+  vet-deploy-as-e2e-tests-target:
+    needs: [pr-norm-branch, build-and-push-branch-unvetted]
+    runs-on: ubuntu-latest
+    env:
+      UNVETTED_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_unvetted:${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun e2e tests against unvetted image
+        run: "MOCK_IMAGE=${UNVETTED_IMAGE} ./script/dockercomposerun -ct"
 
-# Push (IF) Vetted Deploy Image
+  # Push (IF) Vetted Deploy Image
   push-branch-vetted-deploy-image:
     needs:
+      - vet-deploy-as-e2e-tests-target
       - build-and-push-branch-unvetted
       - pr-norm-branch
     uses: brianjbayer/actions-image-cicd/.github/workflows/pull_push_image.yml@main
@@ -57,4 +66,15 @@ jobs:
     secrets:
       registry_u: ${{ secrets.DOCKER_HUB_USERNAME }}
       registry_p: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+  # Vet Dev Environment Image
+  vet-devenv-as-e2e-tests-target:
+    needs: [pr-norm-branch, build-and-push-branch-devenv]
+    runs-on: ubuntu-latest
+    env:
+      DEVENV_IMAGE: ${{ github.repository }}_${{ needs.pr-norm-branch.outputs.name }}_dev:${{ github.event.pull_request.head.sha }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: dockercomposerun e2e tests against devenv image
+        run: "MOCK_IMAGE=${DEVENV_IMAGE} ./script/dockercomposerun -dt"
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,23 @@ For example...
 MOCK_SRC=${PWD} MOCK_IMAGE=mock-rta-dev ./script/dockercomposerun -d
 ```
 
+### Running the End-To-End Tests
+As part of the Continuous Integration (CI) workflow for this
+project, the
+[random_thoughts_api_e2e](https://github.com/brianjbayer/random_thoughts_api_e2e)
+End-To-End (E2E) tests are run against the mock server images
+using the docker compose framework with the `-t` (tests) option.
+
+You can run these E2E tests against the official images or
+specify your own images with the `MOCK_IMAGE` environment
+variable.
+
+For example, to run the E2E tests against your own development
+environment image, run the following command...
+```
+MOCK_IMAGE=mock-rta-dev ./script/dockercomposerun -dt
+```
+
 ## Specifications
 
 > This project leverages the mega-awesome

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,4 +1,4 @@
 version: '3.8'
 services:
-  browsertests:
+  mock:
     image: "${MOCK_IMAGE}"

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  e2etests:
+    # Pin tag to ensure version matching between tests and mock
+    image: "${E2ETESTS_IMAGE:-brianjbayer/random_thoughts_api_e2e:593c13be429a2d43d887b2be175134b44c83c978}"
+    container_name: ${E2ETESTS_HOSTNAME:-e2etests}
+    environment:
+      - E2E_BASE_URL=http://${MOCK_HOSTNAME:-mock}:${PORT:-3000}
+    depends_on:
+      mock:
+        condition: service_healthy
+
+  mock:
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:${PORT:-3000}/readyz"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+    command: ./script/run server

--- a/script/dockercomposerun
+++ b/script/dockercomposerun
@@ -11,10 +11,11 @@
 # OPTIONS:
 # -c: Use the docker-compose CI environment with MOCK_IMAGE
 # -d: Use the docker-compose Dev environment with MOCK_IMAGE
+# -t: Run the e2e tests (and not the mock service)
 # ----------------------------------------------------------------------
 
 usage() {
-  echo "Usage: $0 [-cd] [CMD]"
+  echo "Usage: $0 [-cdt] [CMD]"
 }
 
 err_exit() {
@@ -29,7 +30,7 @@ err_exit() {
 set -e
 
 # Handle options
-while getopts ":cd" options; do
+while getopts ":cdt" options; do
   case "${options}" in
     c)
       echo "CI Environment"
@@ -39,6 +40,11 @@ while getopts ":cd" options; do
     d)
       echo "Development Environment"
       devenv=true
+      ;;
+
+    t)
+      echo "Running End-To-End (E2E) Tests"
+      run_e2etests=true
       ;;
 
     \?)
@@ -74,6 +80,13 @@ fi
 echo "...COMMAND: [${docker_compose_command}]"
 echo ''
 
+if [ ! -z ${run_e2etests} ]; then
+  echo "...Running E2E Tests Image [${E2ETESTS_IMAGE}] against Image [${MOCK_IMAGE}]"
+  docker_compose_command="${docker_compose_command} -f docker-compose.e2e.yml "
+fi
+echo "...COMMAND: [${docker_compose_command}]"
+echo ''
+
 echo 'DOCKER-COMPOSE CONFIGURATION...'
 $docker_compose_command config
 echo ''
@@ -92,19 +105,27 @@ echo ''
 echo "DOCKER-COMPOSE RUNNING [$@]..."
 # Allow to fail but catch return code
 set +e
-# Specify the --service-ports option to expose app's PORTS
-# on host machine (by default docker-compose run does not
-# expose host ports)
-$docker_compose_command run --rm --service-ports mock "$@"
-run_return_code=$?
-# NOTE return code must be caught before any other command
+
+if [ -z ${run_e2etests} ]; then
+  # Specify the --service-ports option to expose app's PORTS
+  # on host machine (by default docker-compose run does not
+  # expose host ports)
+  $docker_compose_command run --rm --service-ports mock "$@"
+  # NOTE return code must be caught before any other command
+  run_return_code=$?
+else
+  echo "RUNNING THE E2E TESTS (e2etests SERVICE) (NOT mock SERVICE)..."
+  $docker_compose_command run --rm e2etests "$@"
+  # NOTE return code must be caught before any other command
+  run_return_code=$?
+fi
 set -e
 echo ''
 
 if [ $run_return_code -eq 0 ]; then
-    run_disposition='PASSED'
+  run_disposition='PASSED'
 else
-    run_disposition='FAILED'
+  run_disposition='FAILED'
 fi
 echo "...RUN [${run_disposition}] WITH RETURN CODE [${run_return_code}]"
 echo ''


### PR DESCRIPTION
# What
This changeset adds running the End-To-End (E2E) Tests to the docker compose framework and the Continuous Integration (CI) workflows to vet both the deploy and development environment images. 

# Why
Running the E2E tests against the built images during CI ensures that this mock server works as expected.

# Change Impact Analysis and Testing
New ability to run E2E tests in docker compose framework verified by...
- [x] Manual testing of default images
- [ ] Successful execution in CI with inspection of output

New vetting of deploy and development environment images in CI verified by...
- [x] Successful execution in CI with inspection of output

Updated README verified by...
- [x] Visual inspection on branch
 
