### PR TITLE
Add database_migration field to readyz response

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -2,7 +2,7 @@ version: '3.8'
 services:
   e2etests:
     # Pin tag to ensure version matching between tests and mock
-    image: "${E2ETESTS_IMAGE:-brianjbayer/random_thoughts_api_e2e:593c13be429a2d43d887b2be175134b44c83c978}"
+    image: "${E2ETESTS_IMAGE:-brianjbayer/random_thoughts_api_e2e:5fbcb40870f546830472701113cd3802f93cdb84}"
     container_name: ${E2ETESTS_HOSTNAME:-e2etests}
     environment:
       - E2E_BASE_URL=http://${MOCK_HOSTNAME:-mock}:${PORT:-3000}

--- a/service/DefaultService.js
+++ b/service/DefaultService.js
@@ -27,6 +27,7 @@ exports.readyzGET = function () {
       status: 200,
       message: 'ready',
       database_connection: 'ok',
+      database_migrations: 'ok',
     };
     if (Object.keys(examples).length > 0) {
       resolve(examples[Object.keys(examples)[0]]);


### PR DESCRIPTION
# What & Why
This changeset adds the "database_migrations": "ok" field and value as this is (soon to be) expected to be present.

This changeset also updates the image tag for the vetting End-to-End tests.

# Change Impact Analysis and Testing
- [x] Vetted against the End-to-End tests (CI)
