### PR TITLE
Match Actual Application by Removing oneOf from get user

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -473,7 +473,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/inline_response_200'
+                $ref: '#/components/schemas/user_response'
         "401":
           description: unauthorized
           content:
@@ -807,14 +807,6 @@ components:
         id: 0
         display_name: display_name
         email: email
-    different_user_response:
-      required:
-      - display_name
-      type: object
-      properties:
-        display_name:
-          minLength: 1
-          type: string
     updated_user:
       type: object
       properties:
@@ -941,10 +933,6 @@ components:
           type: string
         message:
           type: string
-    inline_response_200:
-      oneOf:
-      - $ref: '#/components/schemas/same_user_response'
-      - $ref: '#/components/schemas/different_user_response'
   securitySchemes:
     bearer:
       type: http

--- a/service/DefaultService.js
+++ b/service/DefaultService.js
@@ -279,12 +279,16 @@ exports.v1UsersIdDELETE = function (id) {
  * show user
  *
  * id String id
- * returns inline_response_200
+ * returns user_response
  * */
 exports.v1UsersIdGET = function (id) {
   return new Promise((resolve, reject) => {
-    const examples = {};
-    examples['application/json'] = '';
+    var examples = {};
+    examples['application/json'] = {
+      "id" : 0,
+      "display_name" : "display_name",
+      "email" : "email",
+    };
     if (Object.keys(examples).length > 0) {
       resolve(examples[Object.keys(examples)[0]]);
     } else {


### PR DESCRIPTION
Updates this mock to reflect the
change to the actual application
Swagger spec where oneOf for get user
was replaced with simpler user_response
schema.  Now in this mock get user
actually resturns a (same) user
response with fields and values.

# What
This changeset removes the oneOf specification from `get /v1/users/{id}` and replaces it with the more generic
`user_response` schema.  This change results in `get /v1/users/{id}` now actually returning a (same) user response with fields and values.

# Why
This is to match the corresponding change and specification in the actual application per https://github.com/brianjbayer/random_thoughts_api/pull/53 and makes the `get /v1/users/{id}` better match the application by returning a non-empty response.

# Change Impact Analysis and Testing
No regressions to existing unchanged functionality vetted by...
- [x]  Running E2E tests (CI)

Changed functionality and Swagger specification verified by...
- [x] Manual inspection of Swagger UI
- [x] Manual testing of `get /v1/users/{id}` using Swagger UI
